### PR TITLE
CI: publish wheels to GitHub Releases

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -62,7 +62,7 @@ jobs:
     name: Publish to GitHub Releases
     needs: wheel
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     permissions:
       contents: write
 
@@ -94,7 +94,7 @@ jobs:
       - name: Create GitHub Release
         run: |
           gh release create "${{ steps.meta.outputs.tag }}" dist/*.whl \
-            --prerelease \
+            ${{ github.event_name == 'push' && '--prerelease' || '' }} \
             --title "pygpubench ${{ steps.meta.outputs.tag }}" \
             --notes "Built from commit ${{ github.sha }}.
 


### PR DESCRIPTION
This lets publish python packages on the Github index. In popcorn-cli we typically publish a new release on every commit to main but I figure @ngc92 would rather more control over when a release gets made so when you want to make one you can go the actions tab and then click a button to make a release

So we can install things such as

` pip install pygpubench --find-links https://github.com/ngc92/pygpubench/releases/latest/download/`

or for a specific version

` pip install pygpubench --find-links https://github.com/ngc92/pygpubench/releases/download/v0.0.2+abc1234/`