### PR TITLE
Fix basic_stats: compute std dev instead of variance

### DIFF
--- a/python/pygpubench/__init__.py
+++ b/python/pygpubench/__init__.py
@@ -1,4 +1,5 @@
 import dataclasses
+import math
 import multiprocessing as mp
 import tempfile
 
@@ -59,7 +60,7 @@ def basic_stats(time_us: list[float]) -> BenchmarkSummary:
     slowest = max(time_us)
     median = sorted(time_us)[len(time_us) // 2]
     mean = sum(time_us) / len(time_us)
-    std = sum(map(lambda x: (x - mean) ** 2, time_us)) / len(time_us)
+    std = math.sqrt(sum(map(lambda x: (x - mean) ** 2, time_us)) / len(time_us))
     return BenchmarkSummary(fastest, slowest, median, mean, std)
 
 def do_bench_isolated(


### PR DESCRIPTION
`basic_stats()` was computing variance (`sum((x-mean)^2) / n`) but storing it in a field named `std` and formatting it with `±` in microseconds