### PR TITLE
Fix time_us containing None when fewer iterations run

### DIFF
--- a/python/pygpubench/__init__.py
+++ b/python/pygpubench/__init__.py
@@ -99,13 +99,12 @@ def do_bench_isolated(
                 raise RuntimeError(f"Benchmark subprocess failed with exit code {process.exitcode}")
 
             # Read results from file
-            results = BenchmarkResult(None, [None] * repeats, None)
+            results = BenchmarkResult(None, [], None)
             for line in f:
                 parts = line.strip().split('\t')
                 if len(parts) == 2 and parts[0].isdigit():
-                    iteration = int(parts[0])
                     time_us = float(parts[1])
-                    results.time_us[iteration] = time_us
+                    results.time_us.append(time_us)
                 elif parts[0] == "event-overhead":
                     results.event_overhead_us = float(parts[1].split()[0])
                 elif parts[0] == "error-count":


### PR DESCRIPTION
- The C++ layer adaptively reduces benchmark iterations to fit a 1s budget, so it may run fewer than `repeats`
- Python pre-allocated `[None] * repeats` and index-assigned, leaving trailing `None`s
- `basic_stats()` would crash on `min()` / `sorted()` / `sum()` with mixed `float` and `None`

So start with an empty list and append each timing value

Don't have high confidence this is needed