### PR TITLE
Use GEMM in L2 persistence CI test

### DIFF
--- a/test/l2_persistence.py
+++ b/test/l2_persistence.py
@@ -11,7 +11,7 @@ evict the parked lines -- unless the harness first releases the carveout and dem
 persisting lines (see ``csrc/clear_l2.cu``). On Hopper/Blackwell the default persisting
 carveout is already nonzero, so a submission only needs the access-policy window.
 
-The test runs the SAME memory-bound GEMV through the isolated benchmark twice:
+The test runs the SAME memory-bound single-column GEMM through the isolated benchmark twice:
   * ``kernel``            -- honest (each iteration reads the weights from a cleared L2).
   * ``kernel_l2_persist`` -- marks the reused weights persisting so they would survive the
                              clear and stay warm across iterations.
@@ -95,8 +95,16 @@ def _install_persistence():
                                   ctypes.byref(val))
 
 
+def _gemm_vec(w, x, out=None):
+    x_col = x[:, None]
+    if out is None:
+        return torch.mm(w, x_col).squeeze(1).contiguous()
+    torch.mm(w, x_col, out=out[:, None])
+    return out
+
+
 def kernel(output, x):
-    torch.mv(_get_state()["w"], x, out=output)
+    _gemm_vec(_get_state()["w"], x, out=output)
 
 
 def kernel_l2_persist(output, x):
@@ -104,7 +112,7 @@ def kernel_l2_persist(output, x):
     if not _installed:
         _install_persistence()
         _installed = True
-    torch.mv(_get_state()["w"], x, out=output)
+    _gemm_vec(_get_state()["w"], x, out=output)
 
 
 def generate_test_case(*, seed):
@@ -113,7 +121,7 @@ def generate_test_case(*, seed):
     x = torch.rand(_M, device="cuda", dtype=torch.float32, generator=gen).contiguous()
     w = _get_state()["w"]
     y = torch.empty(w.shape[0], device="cuda", dtype=torch.float32).contiguous()
-    expected = torch.mv(w, x).contiguous()
+    expected = _gemm_vec(w, x)
     return (y, x), (expected, 1e-2, 1e-2)
 
 


### PR DESCRIPTION
## Summary

Update the L2 persistence regression test to use a single-column GEMM (`torch.mm(w, x[:, None])`) instead of GEMV (`torch.mv`). The RHS remains logically vector-shaped for the benchmark, but keeping it rank-2 avoids the flaky `cublasSgemv` path that failed in Modal L4 CI.

## Root cause

The failing GitHub Actions job hit `CUBLAS_STATUS_INVALID_VALUE` inside `torch.mv(w, x)` while generating expected outputs for `test/l2_persistence.py`. The previous lazy CUDA initialization fix moved the failure site but did not remove the fragile cuBLAS GEMV dispatch.

## Validation

- `python3 -m py_compile test/l2_persistence.py`
- `git diff --check`
- Full Modal L4 GPU test suite using the failed workflow wheel artifact from run `27183274114`: passed, with `l2_persistence.py` reporting `hacked/honest median ratio = 0.998` and `OK: L2 persistence confers no benchmark advantage.`
- Narrowed Modal L4 `l2_persistence.py` rerun 3 additional times with the same failed workflow wheel artifact: all passed.

## Notes

T4 is not a useful target for this regression test because Turing does not support the persisting-L2 behavior being exercised. L4 remains the intended CI target for this check.
